### PR TITLE
将PDF导出改为SVG导出

### DIFF
--- a/tools/heatmap/index.html
+++ b/tools/heatmap/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>热图在线生成器</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js"></script>
     <style>
@@ -405,7 +404,7 @@
                     <div class="btn-group">
                         <button onclick="generatePlot()">🔄 生成热图</button>
                         <button onclick="exportPNG()" class="secondary">📷 导出PNG</button>
-                        <button onclick="exportPDF()">📄 导出PDF</button>
+                        <button onclick="exportSVG()">📄 导出SVG</button>
                         <button onclick="exportCSV()">📑 导出CSV</button>
                     </div>
                 </div>
@@ -855,7 +854,7 @@
             });
         }
 
-        function exportPDF() {
+        function exportSVG() {
             if (!currentData) {
                 alert('请先生成热图！');
                 return;
@@ -866,17 +865,23 @@
                 scale: 2
             }).then(canvas => {
                 const imgData = canvas.toDataURL('image/png');
-                const { jsPDF } = window.jspdf;
-                const pdf = new jsPDF({
-                    orientation: 'landscape',
-                    unit: 'mm',
-                    format: 'a4'
-                });
+                const width = canvas.width;
+                const height = canvas.height;
 
-                const imgWidth = 280;
-                const imgHeight = canvas.height * imgWidth / canvas.width;
-                pdf.addImage(imgData, 'PNG', 10, 10, imgWidth, imgHeight);
-                pdf.save('heatmap.pdf');
+                // 创建SVG
+                const svg = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+    <image width="${width}" height="${height}" xlink:href="${imgData}"/>
+</svg>`;
+
+                // 下载SVG
+                const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+                const link = document.createElement('a');
+                link.href = URL.createObjectURL(blob);
+                link.download = 'heatmap.svg';
+                link.click();
+                URL.revokeObjectURL(link.href);
             });
         }
 

--- a/tools/volcano/index.html
+++ b/tools/volcano/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>火山图在线生成器</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js"></script>
     <style>
@@ -424,7 +423,7 @@
                     <div class="btn-group">
                         <button onclick="generatePlot()">🔄 生成图表</button>
                         <button onclick="exportPNG()" class="secondary">📷 导出PNG</button>
-                        <button onclick="exportPDF()">📄 导出PDF</button>
+                        <button onclick="exportSVG()">📄 导出SVG</button>
                         <button onclick="exportCSV()">📑 导出数据CSV</button>
                     </div>
                     <button onclick="generateRandomData()" style="width: 100%; margin-top: 10px; background: #9b59b6;">
@@ -896,24 +895,30 @@
             });
         }
 
-        function exportPDF() {
+        function exportSVG() {
             const plot = document.getElementById('volcanoPlot');
             html2canvas(plot, {
                 backgroundColor: '#ffffff',
                 scale: 2
             }).then(canvas => {
                 const imgData = canvas.toDataURL('image/png');
-                const { jsPDF } = window.jspdf;
-                const pdf = new jsPDF({
-                    orientation: 'landscape',
-                    unit: 'mm',
-                    format: 'a4'
-                });
+                const width = canvas.width;
+                const height = canvas.height;
 
-                const imgWidth = 280;
-                const imgHeight = canvas.height * imgWidth / canvas.width;
-                pdf.addImage(imgData, 'PNG', 10, 10, imgWidth, imgHeight);
-                pdf.save('volcano_plot.pdf');
+                // 创建SVG
+                const svg = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+    <image width="${width}" height="${height}" xlink:href="${imgData}"/>
+</svg>`;
+
+                // 下载SVG
+                const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+                const link = document.createElement('a');
+                link.href = URL.createObjectURL(blob);
+                link.download = 'volcano_plot.svg';
+                link.click();
+                URL.revokeObjectURL(link.href);
             });
         }
 


### PR DESCRIPTION
- 移除jsPDF库依赖
- 将volcano和heatmap工具的exportPDF函数改为exportSVG
- 实现真正的SVG文件导出功能
- SVG包含base64编码的PNG图像，确保兼容性
- 更新按钮文本从"导出PDF"改为"导出SVG"
- 生成的SVG文件可以在任何支持SVG的应用中打开