### PR TITLE
重新实现SVG导出为真正的矢量图

### DIFF
--- a/tools/heatmap/index.html
+++ b/tools/heatmap/index.html
@@ -859,30 +859,88 @@
                 alert('请先生成热图！');
                 return;
             }
-            const plot = document.getElementById('heatmapPlot');
-            html2canvas(plot, {
-                backgroundColor: '#ffffff',
-                scale: 2
-            }).then(canvas => {
-                const imgData = canvas.toDataURL('image/png');
-                const width = canvas.width;
-                const height = canvas.height;
 
-                // 创建SVG
-                const svg = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-     width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
-    <image width="${width}" height="${height}" xlink:href="${imgData}"/>
+            const { data, rowNames, colNames } = currentData;
+            const cellSize = parseInt(document.getElementById('cellSize').value);
+            const fontSize = parseInt(document.getElementById('fontSize').value);
+            const showValues = document.getElementById('showValues').checked;
+            const showGrid = document.getElementById('showGrid').checked;
+
+            const rowCount = data.length;
+            const colCount = data[0].length;
+
+            const labelWidth = 100;
+            const labelHeight = 60;
+            const width = labelWidth + colCount * cellSize;
+            const height = labelHeight + rowCount * cellSize;
+
+            // 计算数值范围
+            const allValues = data.flat();
+            const minVal = Math.min(...allValues);
+            const maxVal = Math.max(...allValues);
+
+            let svgContent = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+    <!-- Background -->
+    <rect width="${width}" height="${height}" fill="white"/>
+
+    <!-- Heatmap cells -->`;
+
+            // 绘制单元格
+            for (let i = 0; i < rowCount; i++) {
+                for (let j = 0; j < colCount; j++) {
+                    const value = data[i][j];
+                    const x = labelWidth + j * cellSize;
+                    const y = labelHeight + i * cellSize;
+                    const color = getColor(value, minVal, maxVal);
+
+                    svgContent += `
+    <rect x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" fill="${color}"${showGrid ? ' stroke="#ddd" stroke-width="0.5"' : ''}/>`;
+
+                    if (showValues && cellSize >= 25) {
+                        const textFontSize = Math.min(fontSize, cellSize / 3);
+                        svgContent += `
+    <text x="${x + cellSize / 2}" y="${y + cellSize / 2}" text-anchor="middle" dominant-baseline="middle" font-family="Arial" font-size="${textFontSize}" fill="#000">${value.toFixed(1)}</text>`;
+                    }
+                }
+            }
+
+            svgContent += `
+
+    <!-- Row labels -->
+    <g font-family="Arial" font-size="${fontSize}" fill="#000">`;
+
+            // 绘制行标签
+            for (let i = 0; i < rowCount; i++) {
+                const y = labelHeight + i * cellSize + cellSize / 2;
+                svgContent += `
+        <text x="${labelWidth - 5}" y="${y}" text-anchor="end" dominant-baseline="middle">${rowNames[i]}</text>`;
+            }
+
+            svgContent += `
+    </g>
+
+    <!-- Column labels -->
+    <g font-family="Arial" font-size="${fontSize}" fill="#000">`;
+
+            // 绘制列标签（旋转45度）
+            for (let j = 0; j < colCount; j++) {
+                const x = labelWidth + j * cellSize + cellSize / 2;
+                svgContent += `
+        <text x="${x}" y="${labelHeight - 5}" text-anchor="start" transform="rotate(-45, ${x}, ${labelHeight - 5})">${colNames[j]}</text>`;
+            }
+
+            svgContent += `
+    </g>
 </svg>`;
 
-                // 下载SVG
-                const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
-                const link = document.createElement('a');
-                link.href = URL.createObjectURL(blob);
-                link.download = 'heatmap.svg';
-                link.click();
-                URL.revokeObjectURL(link.href);
-            });
+            // 下载SVG
+            const blob = new Blob([svgContent], { type: 'image/svg+xml;charset=utf-8' });
+            const link = document.createElement('a');
+            link.href = URL.createObjectURL(blob);
+            link.download = 'heatmap.svg';
+            link.click();
+            URL.revokeObjectURL(link.href);
         }
 
         function exportCSV() {

--- a/tools/volcano/index.html
+++ b/tools/volcano/index.html
@@ -896,30 +896,160 @@
         }
 
         function exportSVG() {
-            const plot = document.getElementById('volcanoPlot');
-            html2canvas(plot, {
-                backgroundColor: '#ffffff',
-                scale: 2
-            }).then(canvas => {
-                const imgData = canvas.toDataURL('image/png');
-                const width = canvas.width;
-                const height = canvas.height;
+            if (currentData.length === 0) {
+                alert('请先生成图表！');
+                return;
+            }
 
-                // 创建SVG
-                const svg = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-     width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
-    <image width="${width}" height="${height}" xlink:href="${imgData}"/>
+            const title = document.getElementById('plotTitle').value;
+            const width = parseInt(document.getElementById('plotWidth').value);
+            const height = parseInt(document.getElementById('plotHeight').value);
+            const fcThreshold = parseFloat(document.getElementById('fcThreshold').value);
+            const pThreshold = parseFloat(document.getElementById('pThreshold').value);
+            const pointSize = parseFloat(document.getElementById('pointSize').value);
+            const pointAlpha = parseFloat(document.getElementById('pointAlpha').value);
+            const upColor = document.getElementById('upColor').value;
+            const downColor = document.getElementById('downColor').value;
+            const nsColor = document.getElementById('nsColor').value;
+            const labelCount = parseInt(document.getElementById('labelCount').value);
+
+            const negLogPThreshold = -Math.log10(pThreshold);
+            const margin = { top: 40, right: 40, bottom: 60, left: 60 };
+            const plotWidth = width - margin.left - margin.right;
+            const plotHeight = height - margin.top - margin.bottom;
+
+            // 获取最显著的基因用于标注
+            const sortedForLabel = [...currentData]
+                .filter(d => d.category !== 'ns')
+                .sort((a, b) => b.negLogP - a.negLogP)
+                .slice(0, labelCount);
+
+            // 计算坐标范围
+            const maxLogFC = Math.max(...currentData.map(d => Math.abs(d.log2fc)));
+            const maxNegLogP = Math.max(...currentData.map(d => d.negLogP));
+            const xRange = Math.ceil(maxLogFC) + 1;
+            const yRange = Math.ceil(maxNegLogP) + 1;
+
+            let svgContent = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+    <!-- Background -->
+    <rect width="${width}" height="${height}" fill="white"/>
+
+    <!-- Grid lines -->
+    <g stroke="#e0e0e0" stroke-width="0.5">`;
+
+            // 绘制网格
+            for (let i = 0; i <= 10; i++) {
+                const x = margin.left + (plotWidth / 10) * i;
+                const y = margin.top + (plotHeight / 10) * i;
+                svgContent += `
+        <line x1="${x}" y1="${margin.top}" x2="${x}" y2="${height - margin.bottom}"/>
+        <line x1="${margin.left}" y1="${y}" x2="${width - margin.right}" y2="${y}"/>`;
+            }
+
+            svgContent += `
+    </g>
+
+    <!-- Threshold lines -->
+    <g stroke="#888" stroke-width="1.5" stroke-dasharray="5,5">`;
+
+            // 垂直阈值线
+            const xPosThreshold = margin.left + ((fcThreshold + xRange) / (2 * xRange)) * plotWidth;
+            const xNegThreshold = margin.left + ((-fcThreshold + xRange) / (2 * xRange)) * plotWidth;
+            svgContent += `
+        <line x1="${xPosThreshold}" y1="${margin.top}" x2="${xPosThreshold}" y2="${height - margin.bottom}"/>
+        <line x1="${xNegThreshold}" y1="${margin.top}" x2="${xNegThreshold}" y2="${height - margin.bottom}"/>`;
+
+            // 水平阈值线
+            const yThreshold = height - margin.bottom - (negLogPThreshold / yRange) * plotHeight;
+            svgContent += `
+        <line x1="${margin.left}" y1="${yThreshold}" x2="${width - margin.right}" y2="${yThreshold}"/>`;
+
+            svgContent += `
+    </g>
+
+    <!-- Axes -->
+    <g stroke="#000" stroke-width="2" fill="none">
+        <path d="M ${margin.left} ${margin.top} L ${margin.left} ${height - margin.bottom} L ${width - margin.right} ${height - margin.bottom}"/>
+    </g>
+
+    <!-- Axis labels -->
+    <text x="${width / 2}" y="${height - 10}" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="#000">Log2 Fold Change</text>
+    <text x="${15}" y="${height / 2}" text-anchor="middle" font-family="Arial" font-size="14" font-weight="bold" fill="#000" transform="rotate(-90, 15, ${height / 2})">-Log10 (P-value)</text>
+
+    <!-- X-axis ticks -->
+    <g font-family="Arial" font-size="12" fill="#000">`;
+
+            // X轴刻度
+            for (let i = -xRange; i <= xRange; i += Math.ceil(xRange / 5)) {
+                const x = margin.left + ((i + xRange) / (2 * xRange)) * plotWidth;
+                svgContent += `
+        <text x="${x}" y="${height - margin.bottom + 20}" text-anchor="middle">${i}</text>
+        <line x1="${x}" y1="${height - margin.bottom}" x2="${x}" y2="${height - margin.bottom + 5}" stroke="#000" stroke-width="1"/>`;
+            }
+
+            svgContent += `
+    </g>
+
+    <!-- Y-axis ticks -->
+    <g font-family="Arial" font-size="12" fill="#000">`;
+
+            // Y轴刻度
+            for (let i = 0; i <= Math.ceil(yRange); i += Math.ceil(yRange / 5)) {
+                const y = height - margin.bottom - (i / yRange) * plotHeight;
+                svgContent += `
+        <text x="${margin.left - 10}" y="${y + 5}" text-anchor="end">${i}</text>
+        <line x1="${margin.left - 5}" y1="${y}" x2="${margin.left}" y2="${y}" stroke="#000" stroke-width="1"/>`;
+            }
+
+            svgContent += `
+    </g>
+
+    <!-- Data points -->`;
+
+            // 绘制数据点
+            currentData.forEach(d => {
+                const x = margin.left + ((d.log2fc + xRange) / (2 * xRange)) * plotWidth;
+                const y = height - margin.bottom - (d.negLogP / yRange) * plotHeight;
+
+                let color;
+                if (d.category === 'up') color = upColor;
+                else if (d.category === 'down') color = downColor;
+                else color = nsColor;
+
+                svgContent += `
+    <circle cx="${x}" cy="${y}" r="${pointSize}" fill="${color}" opacity="${pointAlpha}"/>`;
+            });
+
+            // 标注基因名
+            if (labelCount > 0) {
+                svgContent += `
+
+    <!-- Gene labels -->
+    <g font-family="Arial" font-size="11" font-weight="bold" fill="#000">`;
+
+                sortedForLabel.forEach(d => {
+                    const x = margin.left + ((d.log2fc + xRange) / (2 * xRange)) * plotWidth;
+                    const y = height - margin.bottom - (d.negLogP / yRange) * plotHeight;
+
+                    svgContent += `
+        <text x="${x + pointSize + 3}" y="${y + 4}">${d.gene}</text>`;
+                });
+
+                svgContent += `
+    </g>`;
+            }
+
+            svgContent += `
 </svg>`;
 
-                // 下载SVG
-                const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
-                const link = document.createElement('a');
-                link.href = URL.createObjectURL(blob);
-                link.download = 'volcano_plot.svg';
-                link.click();
-                URL.revokeObjectURL(link.href);
-            });
+            // 下载SVG
+            const blob = new Blob([svgContent], { type: 'image/svg+xml;charset=utf-8' });
+            const link = document.createElement('a');
+            link.href = URL.createObjectURL(blob);
+            link.download = 'volcano_plot.svg';
+            link.click();
+            URL.revokeObjectURL(link.href);
         }
 
         function exportCSV() {


### PR DESCRIPTION
- 移除base64编码的PNG嵌入方式
- 直接生成SVG矢量元素
- volcano工具：生成网格、阈值线、坐标轴、数据点圆圈、基因标签等SVG元素
- heatmap工具：生成热图矩形、网格、数值文本、行列标签等SVG元素
- 生成的SVG文件可无损缩放
- 可在Illustrator、Inkscape等矢量图编辑软件中编辑
- 文件大小更小，更适合科学出版
- 保留html2canvas库用于PNG导出